### PR TITLE
Storybook 배포 브랜치별로 따로 볼 수 있도록 GitHub Actions 설정 추가

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,9 +27,24 @@ jobs:
       - run: npm ci
       - run: npm run build-storybook
 
+      # extract branch name
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }}
+
       - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: ./storybook-static
-          commit_message: https://Yapp-17th.github.io/Web_2_Client/
+          destination_dir: ${{ env.BRANCH_NAME }}
+          commit_message: https://Yapp-17th.github.io/Web_2_Client/${{ env.BRANCH_NAME }}


### PR DESCRIPTION
> resolve #49 
- Branch 이름 얻기
  - echo "::set-env name=variable_name::content" 이거는 Deprecate 되어서 사용하면 안됨
  - echo "{name}={value}" >> $GITHUB_ENV 를 사용해야 함
  - name은 ${{ env.name }} 형식으로 사용할 수 있음
  - 브랜치 이름에 '#'이 포함되어 있으므로 이를 제거해야 함
    - [tr](https://stackoverflow.com/questions/10282540/delete-a-specific-string-with-tr)을 이용하려 했으나 공백으로 치환이 불가능하다는 문제가 생김
    - [cut](https://bbolmin.tistory.com/32)으로 대체하려 했으나 구분자를 기준으로 분리된 것 중 하나를 선택하는 형태라 실패
    - 결국 [sed](https://www.theunixschool.com/2014/08/sed-examples-remove-delete-chars-from-line-file.html)를 활용해 #을 공백으로 치환함
- PR 혹은 master에 merge시 브랜치 이름 폴더에 빌드되도록 destination_dir 추가
- commit_message url에 브랜치 이름을 포함하여 커밋된 브랜치에 따른 URL 포함하도록 함

**reference**
- [Deprecating set-env and add-path commands, alternative?](https://github.community/t/deprecating-set-env-and-add-path-commands-alternative/136147)
- [GitHub Actions: Setting an environment variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)