### PR TITLE
스크롤바 디자인 적용

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -34,4 +34,15 @@
     src: url('fonts/AppleSDGothicNeoB.ttf') format('truetype');
     unicode-range: U+AC00-D7AF;
   }
+
+  ::-webkit-scrollbar       {
+      background-color:white;
+      width:14px;
+  }
+  ::-webkit-scrollbar-track {
+      background-color:white
+  }
+  ::-webkit-scrollbar-thumb {
+      background-color:#0c0c59;
+  }
 </style>

--- a/src/index.scss
+++ b/src/index.scss
@@ -42,3 +42,14 @@
 body {
   font-family: 'AppleSDGothicNeoM00';
 }
+
+::-webkit-scrollbar       {
+    background-color:white;
+    width:14px;
+}
+::-webkit-scrollbar-track {
+    background-color:white
+}
+::-webkit-scrollbar-thumb {
+    background-color:#0c0c59;
+}


### PR DESCRIPTION
> resolve #54 
- [x] ::-webkit-scrollbar, ::-webkit-scrollbar-track, ::-webkit-scrollbar-thumb 을 사용해서 디자인 적용
  - body::-webkit-scrollbar 이런식으로 하면 div 내부적으로 scroll 하는 것에서 적용되지 않음
- [x] storybook에서도 적용되도록 .storybook/preview-head.html에 css 추가
<img width="573" alt="Screen Shot 2020-11-16 at 11 54 45 PM" src="https://user-images.githubusercontent.com/16266103/99268038-03c6c480-2868-11eb-96c0-03a94866b76f.png">
<img width="381" alt="Screen Shot 2020-11-16 at 11 26 05 PM" src="https://user-images.githubusercontent.com/16266103/99268062-0aedd280-2868-11eb-9d62-8b0d6f9e7a53.png">
