### PR TITLE
로그인 후 첫 화면(가이드, 질문 등록 선택 페이지) 퍼블리싱 및 기능 구현

### DIFF
--- a/src/components/TextBox/TextBox.js
+++ b/src/components/TextBox/TextBox.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const Wrapper = styled.div`
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const FirstText = styled.div`
+  font-family: AppleSDGothicNeoEB00;
+  font-size: 36px;
+`;
+
+const SecondText = styled.div`
+  font-size: 24px;
+  color: #3d3d3d;
+`;
+
+export default function TextBox({ topText, bottomText }) {
+  return (
+    <Wrapper>
+      <FirstText>{topText}</FirstText>
+      <SecondText>{bottomText}</SecondText>
+    </Wrapper>
+  );
+}
+
+TextBox.propTypes = {
+  topText: PropTypes.string.isRequired,
+  bottomText: PropTypes.string.isRequired,
+};

--- a/src/components/TextBox/TextBox.stories.js
+++ b/src/components/TextBox/TextBox.stories.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import TextBox from './TextBox';
+
+export default {
+  title: 'TextBox',
+  component: TextBox,
+};
+
+export const Controls = () => (
+  <TextBox
+    topText="실제 면접을 본다고 생각하고 상황을 상상해보세요"
+    bottomText="3분 동안 예상 면접 질문에 대해 답변을 생각해 보세요."
+  />
+);

--- a/src/components/TextBox/index.js
+++ b/src/components/TextBox/index.js
@@ -1,0 +1,1 @@
+export { default } from './TextBox';

--- a/src/pages/SelfTrainEntry/SelectCard.js
+++ b/src/pages/SelfTrainEntry/SelectCard.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import Icon from '../../components/Icon';
+
+import guideImage from '../../assets/images/illust_3.png';
+import addQuestionImage from '../../assets/images/illust_2.png';
+
+const Wrapper = styled.div`
+  user-select: none;
+  width: 390px;
+  height: 495px;
+  display: flex;
+  align-itmes: center;
+  justify-content: center;
+  margin: 17px;
+`;
+
+const WrapContainer = styled.div`
+  position: relative;
+  flex-direction: column;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 374px;
+  height: 479px;
+  border-radius: 20px;
+  box-shadow: 0 6px 12px 0 rgba(4, 4, 161, 0.1);
+  ${({ clicked }) => clicked && 'border: solid 4px #6e6eff;'}
+`;
+
+const WrapIcon = styled.div`
+  position: absolute;
+  top: 24px;
+  right: 28px;
+`;
+
+const WrapImage = styled.img`
+  height: 248px;
+`;
+
+const WrapMiddleText = styled.div`
+  font-family: AppleSDGothicNeoB00;
+  font-size: 24px;
+  ${({ clicked }) => clicked && 'color: #6e6eff;'}
+  padding: 27px;
+`;
+
+const WrapBottomText = styled.div`
+  font-family: AppleSDGothicNeoM00;
+  font-size: 20px;
+  color: #3d3d3d;
+  padding: 3px;
+`;
+
+const GUIDE_IMAGE = 1;
+
+export default function SelectCard({ kind, clicked, func }) {
+  return (
+    <Wrapper onClick={func}>
+      <WrapContainer clicked={clicked}>
+        <WrapIcon>
+          {clicked && (
+            <Icon type="check_circle_white" alt="Check Circle White" />
+          )}
+        </WrapIcon>
+        <WrapImage
+          src={kind === GUIDE_IMAGE ? guideImage : addQuestionImage}
+          alt="Button Middle"
+        />
+        <WrapMiddleText clicked={clicked}>
+          {kind === GUIDE_IMAGE ? '면접 질문 가이드' : '면접 질문 등록 후 연습'}
+        </WrapMiddleText>
+        <WrapBottomText>
+          {kind === GUIDE_IMAGE
+            ? '기존에 있는 질문으로 면접을'
+            : '면접 질문 리스트를 설정하고'}
+        </WrapBottomText>
+        <WrapBottomText>
+          {kind === GUIDE_IMAGE ? '연습해보세요.' : '연습할 수 있어요.'}
+        </WrapBottomText>
+      </WrapContainer>
+    </Wrapper>
+  );
+}
+
+SelectCard.propTypes = {
+  kind: PropTypes.number.isRequired,
+  clicked: PropTypes.bool,
+  func: PropTypes.func,
+};
+
+SelectCard.defaultProps = {
+  clicked: undefined,
+  func: () => {},
+};

--- a/src/pages/SelfTrainEntry/SelectCard.js
+++ b/src/pages/SelfTrainEntry/SelectCard.js
@@ -52,6 +52,9 @@ const WrapBottomText = styled.div`
   font-size: 20px;
   color: #3d3d3d;
   padding: 3px;
+  white-space: pre;
+  text-align: center;
+  line-height: 1.5;
 `;
 
 const GUIDE_IMAGE = 1;
@@ -74,11 +77,8 @@ export default function SelectCard({ kind, clicked, func }) {
         </WrapMiddleText>
         <WrapBottomText>
           {kind === GUIDE_IMAGE
-            ? '기존에 있는 질문으로 면접을'
-            : '면접 질문 리스트를 설정하고'}
-        </WrapBottomText>
-        <WrapBottomText>
-          {kind === GUIDE_IMAGE ? '연습해보세요.' : '연습할 수 있어요.'}
+            ? '기존에 있는 질문으로 면접을\n연습해보세요.'
+            : '면접 질문 리스트를 설정하고\n연습할 수 있어요.'}
         </WrapBottomText>
       </WrapContainer>
     </Wrapper>

--- a/src/pages/SelfTrainEntry/SelfTrainEntry.js
+++ b/src/pages/SelfTrainEntry/SelfTrainEntry.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import TextBox from '../../components/TextBox';
+import SelectCard from './SelectCard';
+import Button from '../../components/Button';
+
+const Wrapper = styled.div`
+  flex: 1;
+  flex-direction: column;
+`;
+const WrapContent = styled.div`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const WrapCardSection = styled.div`
+  display: flex;
+  padding: 80px;
+`;
+
+// TODO: 이부분 API 처리를 통해 redux에서 상태 들고 와야 함
+const NAME = '홍길동';
+
+const SELECT_NOTHING = 0;
+const GUIDE_BUTTON = 1;
+const ADD_QUESTION_BUTTON = 2;
+
+export default function SelfTrainEntry() {
+  const [clicked, setClicked] = useState(SELECT_NOTHING);
+
+  const handleToggle = (select) => {
+    if (select === clicked) return setClicked(SELECT_NOTHING);
+    return setClicked(select);
+  };
+
+  return (
+    <Wrapper>
+      <WrapContent>
+        <TextBox
+          topText={`${NAME}님 화상 면접을 혼자 연습해보세요`}
+          bottomText="원하는 기능을 선택하여 화상 면접을 대비해 보세요."
+        />
+        <WrapCardSection>
+          <SelectCard
+            kind={GUIDE_BUTTON}
+            clicked={clicked === GUIDE_BUTTON}
+            func={() => handleToggle(GUIDE_BUTTON)}
+          />
+          <SelectCard
+            kind={ADD_QUESTION_BUTTON}
+            clicked={clicked === ADD_QUESTION_BUTTON}
+            func={() => handleToggle(ADD_QUESTION_BUTTON)}
+          />
+        </WrapCardSection>
+        <Button theme="blue" text="다음" />
+      </WrapContent>
+    </Wrapper>
+  );
+}

--- a/src/pages/SelfTrainEntry/SelfTrainEntry.stories.js
+++ b/src/pages/SelfTrainEntry/SelfTrainEntry.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import SelfTrainEntry from './SelfTrainEntry';
+import SelectCard from './SelectCard';
+
+export default {
+  title: 'Page/SelfTrainEntry',
+  component: SelfTrainEntry,
+};
+
+export const SelfTrainEntryPage = () => <SelfTrainEntry />;
+export const SelectCardDefault = () => (
+  <>
+    <SelectCard kind={0} />
+    <SelectCard kind={0} clicked />
+
+    <SelectCard kind={1} />
+    <SelectCard kind={1} clicked />
+  </>
+);

--- a/src/pages/SelfTrainEntry/index.js
+++ b/src/pages/SelfTrainEntry/index.js
@@ -1,0 +1,1 @@
+export { default } from './SelfTrainEntry';


### PR DESCRIPTION
> resolve #74

- 은비님 디자인 해주신 로그인 후 Entry 패이지 와이어프레임 적용 완료
- SelectCard 컴포넌트 구현 완료
  - 선택에 따라 표현되는 렌더링 처리 구현 완료
- #70 에서 제작한 TextBox 컴포넌트에 의존성이 있어서 cherry-pick으로 커밋 가져옴

<img width="1236" alt="Screen Shot 2020-12-01 at 8 20 45 PM" src="https://user-images.githubusercontent.com/16266103/100734248-b4a99380-3412-11eb-906f-ba508ea98272.png">

## TODO
- [ ] API 로직 및 상태 추가 

https://yapp-17th.github.io/Web_2_Client/feat/74/?path=/story/page-selftrainentry--self-train-entry-page